### PR TITLE
Increment monitor id by 1 for ddcutil

### DIFF
--- a/hypr_brightness.sh
+++ b/hypr_brightness.sh
@@ -34,6 +34,6 @@ if [ "$focused_name" == "eDP-1" ]; then
         brillo -u 150000 -A 8
     fi
 else
-    focused_id=$(echo $monitor_data | jq -r '.[] | select(.focused == true) | .id')
+    focused_id=$(echo $monitor_data | jq -r '.[] | select(.focused == true) | .id + 1')
     ddcutil --sleep-multiplier=.2 --display=$focused_id setvcp 10 $direction 15
 fi


### PR DESCRIPTION
ddcutil lists displays starting from index 1, as seen in output from `ddcutil detect`:

```
$ ddcutil detect
Display 1
   I2C bus:  /dev/i2c-4
   DRM connector:           card1-DP-2
   EDID synopsis:
      ...
   VCP version:         2.2
```

yet hyprctl starts indexing them from 0:
```
$ hyprctl monitors -j
[{
    "id": 0,
    "name": "DP-2",
```

so we should counter it by adding 1 to the id from `hyprctl`